### PR TITLE
build: 의존성 spring-boot-starter-web 추가, application.yml 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,15 +25,13 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
 }
 
 tasks.named('test') {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,19 @@
-spring.application.name=ReservationProject
+server:
+  port: 8083
+spring:
+  datasource:
+    username: root
+    password: 1234
+    url: jdbc:mysql://localhost:3306/project_db?serverTimezone=UTC&characterEncoding=UTF-8
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+    defer-datasource-initialization: true
+  data:
+    redis:
+      host: localhost
+      port: 6379


### PR DESCRIPTION
## 변경사항
### AS-IS
- `spring-boot-starter-web` 의존성 추가
- application.yml 수정
  - server:port
  - jpa
  - datasource
  - data:redis
  - DB 연동은 문제없음
- 로컬환경에서 Docker 구동 (OS : MacOS)
  - MySQL 8.4.0 container
  - Redis container
### TO-BE
- feature/customer, seller 진행해야함
- 엔티티 생성 후 DB 테스트 진행
## 테스트
- [ ] 테스트 코드
- [ ] API 테스트